### PR TITLE
Upgrade guzzle to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Create client:
 
 ```php
 
-$httpClient = new \Guzzle\Http\Client('https://api.geckoboard.com');
+$httpClient = new \GuzzleHttp\Client(['base_uri' => 'https://api.geckoboard.com']);
 $client = new \Kwk\Geckoboard\Dataset\Client($httpClient, 'YOUR_API_KEY');
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "require": {
     "php": ">=5.5.0",
-    "guzzlehttp/guzzle": "^5"
+    "guzzlehttp/guzzle": "^6"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/src/RequestFactory.php
+++ b/src/RequestFactory.php
@@ -4,6 +4,7 @@ namespace Kwk\Geckoboard\Dataset;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Psr7\Request;
 
 class RequestFactory
 {
@@ -34,16 +35,14 @@ class RequestFactory
      */
     public function getCreateRequest(DataSetInterface $dataSet)
     {
-        return $this->client->createRequest(
+        return new Request(
             'PUT',
             sprintf('/datasets/%s', $dataSet->getName()),
             [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-                'auth'    => [$this->apiKey, ''],
-                'json'    => $dataSet->getDefinition(),
-            ]
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Basic '.base64_encode($this->apiKey.':'),
+            ],
+            \GuzzleHttp\json_encode($dataSet->getDefinition())
         );
     }
 
@@ -60,16 +59,14 @@ class RequestFactory
             $data[] = $row->getData();
         }
 
-        return $this->client->createRequest(
+        return new Request(
             'POST',
             sprintf('/datasets/%s/data', $datasetName),
             [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-                'auth'    => [$this->apiKey, ''],
-                'json'    => ['data' => $data],
-            ]
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Basic '.base64_encode($this->apiKey.':'),
+            ],
+            \GuzzleHttp\json_encode(['data' => $data])
         );
     }
 
@@ -86,16 +83,14 @@ class RequestFactory
             $data[] = $row->getData();
         }
 
-        return $this->client->createRequest(
+        return new Request(
             'PUT',
             sprintf('/datasets/%s/data', $datasetName),
             [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                ],
-                'auth'    => [$this->apiKey, ''],
-                'json'    => ['data' => $data],
-            ]
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Basic '.base64_encode($this->apiKey.':'),
+            ],
+            \GuzzleHttp\json_encode(['data' => $data])
         );
     }
 
@@ -106,12 +101,13 @@ class RequestFactory
      */
     public function getDeleteRequest($datasetName)
     {
-        return $this->client->createRequest(
+        return new Request(
             'DELETE',
             sprintf('/datasets/%s', $datasetName),
             [
-                'auth' => [$this->apiKey, ''],
-            ]
+                'Authorization' => 'Basic '.base64_encode($this->apiKey.':'),
+            ],
+            \GuzzleHttp\json_encode(['data' => $data])
         );
     }
 }


### PR DESCRIPTION
It makesthe lib works with guzzle 6.
I kept RequestFactory as a transitional class but I think we could also directly call GuzzleHttp\Client::request into Kwk\Geckoboard\Dataset\Client and deprecate definitely RequestFactory

Anyway here's my PR